### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Deposit Account Management [![Build Status](https://api.travis-ci.com/apache/fineract-cn-deposit-account-management.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-deposit-account-management) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-deposit-account-management)](https://hub.docker.com/r/apache/fineract-cn-deposit-account-management/builds) 
+# Apache Fineract CN Deposit Account Management [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-deposit-account-management)](https://hub.docker.com/r/apache/fineract-cn-deposit-account-management/builds) 
 
 This project provides a services to create deposit accounts, e.g. checking, savings, and shares.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-deposit-account-management).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.